### PR TITLE
docs: update README and CHANGELOG to match current plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,18 @@ All notable changes to the EmDash Analytics Plugin will be documented here.
 
 ## [1.0.0] — 2026-04-04
 
-Initial release. Google Tag Manager injection, GA4 and Search Console OAuth, header/footer script injection, UTM attribution engine, and call tracking provisioning for EmDash CMS.
+Initial release. Tag management, native ad platform tracking pixels, GA4 and Search Console OAuth, header/footer script injection, UTM attribution engine, and call tracking provisioning for EmDash CMS.
 
 ### Features
 - **Google Tag Manager injection** — Automatic `<head>` and `<body>` injection with noscript fallback
-- **Google Analytics 4** — One-click OAuth connection; sessions, users, and traffic sources in the EmDash admin
+- **Google Analytics 4** — Native toggle + one-click OAuth connection; sessions, users, and traffic sources in the EmDash admin
 - **Google Search Console** — Clicks, impressions, CTR, and average position via OAuth
-- **Header/footer script injection** — Paste in any third-party snippet (Meta Pixel, LinkedIn Insight, Hotjar, etc.)
+- **Native ad platform tracking pixels** — One-toggle setup with built-in help guides for Meta (Facebook) Pixel, LinkedIn Insights Tag, TikTok Pixel, Microsoft (Bing) UET Tag, Pinterest Tag, and Nextdoor Pixel
+- **Header/footer script injection** — Paste in any third-party snippet (Hotjar, Clarity, CallRail, etc.)
 - **UTM persistence engine** — First-touch attribution captured in cookies and pushed to dataLayer
 - **Call tracking provisioning** — Local and toll-free tracking numbers provisioned directly from the EmDash admin
 - **Basic call log** — Caller ID, duration, timestamp, and attributed marketing source per call
-- **Ed25519 license validation** — Cryptographic domain-bound license verification with 24-hour KV cache
+- **Three-tab admin UI** — Marketing ROI dashboard, Tracking Pixels configuration, and License & Google settings
+- **Compare-and-swap settings saves** — Atomic conflict detection prevents race conditions between admin tabs
+- **Ed25519 license validation** — Cryptographic domain-bound license verification with KV cache (expiry driven by the signed token, not a fixed TTL)
 - **Fail-open architecture** — Cached tracking scripts keep running if the backend is temporarily unreachable

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 <p align="center">
-  <img src="assets/banner.svg" alt="EmDash Analytics Plugin — Google Tag Manager, analytics, and call tracking for EmDash CMS by ROI Insights from MosierData" width="100%" />
+  <img src="assets/banner.svg" alt="EmDash Analytics Plugin — tag management, tracking pixels, analytics, and call tracking for EmDash CMS by ROI Insights from MosierData" width="100%" />
 </p>
 
 # EmDash Analytics Plugin
 
-**Google Tag Manager, analytics, and call tracking for EmDash CMS — provided by [ROI Insights](https://roiknowledge.com/?utm_source=github&utm_medium=referral&utm_campaign=emdash-analytics) from [MosierData](https://mosierdata.com/?utm_source=github&utm_medium=referral&utm_campaign=emdash-analytics).**
+**Tag management, tracking pixels, analytics, and call tracking for EmDash CMS — provided by [ROI Insights](https://roiknowledge.com/?utm_source=github&utm_medium=referral&utm_campaign=emdash-analytics) from [MosierData](https://mosierdata.com/?utm_source=github&utm_medium=referral&utm_campaign=emdash-analytics).**
 
-Core tracking features and basic analytics are completely free — no trial, no time limit, no credit card. Premium upgrades are available when you're ready for AI-powered call analysis, lead scoring, and advanced attribution.
+Native one-toggle setup for Google Tag Manager, GA4, Meta Pixel, LinkedIn, TikTok, Microsoft Ads, Pinterest, and Nextdoor — plus call tracking, custom script injection, and an embedded analytics dashboard.
+
+Core features are completely free — just register for a free license key (no credit card required). Premium upgrades are available when you're ready for AI-powered call analysis, lead scoring, and advanced attribution.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![EmDash Compatible](https://img.shields.io/badge/EmDash-v0.1.0+-brightgreen.svg)](https://github.com/emdash-cms/emdash)
@@ -22,7 +24,7 @@ If you're spending money on marketing, that's not a minor inconvenience. Every d
 
 ## The Fix
 
-Install this plugin. In about 60 seconds, you'll have Google Tag Manager injecting into your `<head>` and `<body>`, Google Analytics 4 and Search Console connected via one-click OAuth, and a place to drop in any other tracking script you need — Meta Pixel, LinkedIn Insight, Hotjar, whatever you're running.
+Install this plugin. In about 60 seconds, you'll have Google Tag Manager injecting into your `<head>` and `<body>`, Google Analytics 4 connected via one-click OAuth, and native toggles for six major ad platforms — Meta, LinkedIn, TikTok, Microsoft, Pinterest, and Nextdoor — each with built-in setup guides so you never have to leave your admin panel.
 
 And if your business depends on phone calls, you can provision a call tracking number right from your EmDash admin. No separate vendor accounts. No code. Just a tracking number that tells you exactly which ad, campaign, or page made the phone ring.
 
@@ -39,14 +41,28 @@ This isn't a demo and it doesn't expire. These features are yours to keep.
 ### Google Tag Manager Injection
 Enter your GTM container ID and the plugin handles the rest — `<head>` script, `<body>` noscript fallback, automatic injection on every page. **You get proper tag management on your EmDash site** without editing a single template file.
 
-### Google Analytics 4 Connection
-Connect your GA4 property with one click through Google OAuth. **You get sessions, active users, traffic sources, and lead data** visible right inside your EmDash admin panel — no more switching between tabs.
+### Google Analytics 4 (Native Toggle)
+Enable GA4 with a single toggle and your Measurement ID — the plugin handles the script injection automatically. Then connect your GA4 property through one-click Google OAuth to see **sessions, active users, traffic sources, and lead data** right inside your EmDash admin. No more logging into a separate analytics dashboard just to check if your traffic went up.
 
 ### Google Search Console Connection
 Link your Search Console property the same way. **You get clicks, impressions, CTR, and average position** for your top queries and pages, all in one dashboard alongside your other metrics.
 
+### Native Ad Platform Tracking Pixels
+Six major advertising platforms have dedicated toggles with built-in setup guides — no code, no copy-paste, no guessing which script goes where:
+
+| Platform | What It Does |
+|----------|-------------|
+| **Meta (Facebook) Pixel** | Tracks conversions from Facebook and Instagram ads, builds retargeting audiences from your visitors, and helps Meta find more people like your best customers |
+| **LinkedIn Insight Tag** | Measures conversions from LinkedIn ads and unlocks Website Demographics — see the job titles, industries, and company sizes of your visitors. Essential for B2B |
+| **TikTok Pixel** | Tracks conversions from TikTok ads and lets the algorithm optimize toward people who actually become leads — not just clickers |
+| **Microsoft (Bing) UET Tag** | Enables conversion tracking and remarketing for Microsoft Advertising across Bing, Yahoo, DuckDuckGo, and partner sites. Often the cheapest cost-per-lead in paid search |
+| **Pinterest Tag** | Tracks conversions from Promoted Pins and builds audiences for Pinterest campaigns. Especially valuable for visual businesses (renovation, landscaping, design) |
+| **Nextdoor Pixel** | Tracks conversions from Nextdoor neighborhood ads — hyper-local targeting for home services, contractors, and any business that serves a specific area |
+
+Each platform includes an expandable help panel explaining what the pixel does, why you'd use it, when to skip it (e.g., if you're already loading it through GTM), and step-by-step instructions for finding your tracking ID.
+
 ### Header & Footer Script Injection
-Need to add a Meta Pixel? LinkedIn Insight tag? Hotjar? Any third-party snippet? Paste it into the header or footer code fields. **You get a universal script injection tool** that works with anything — not just Google products.
+Running a platform we don't have a native toggle for? Hotjar, Clarity, CallRail, or anything else? Paste the snippet into the header or footer code fields. **If it's a tracking script, you can add it here** — no developer required.
 
 ### Call Tracking
 Provision a local or toll-free tracking number directly from your EmDash admin panel. Calls forward to your real business number instantly. **You know exactly which marketing channel, campaign, or keyword drove each call** — no guessing, no asking "how'd you hear about us?"
@@ -60,13 +76,14 @@ Every inbound call is logged with caller ID, duration, timestamp, and the attrib
 
 ## Premium Upgrades (Optional)
 
-The free tier stays free forever. Paid tiers add AI intelligence and deeper attribution for businesses that need to know not just that a lead came in — but whether it was any good.
+The free tier stays free forever. Paid tiers add AI-powered intelligence and deeper attribution for businesses that want to know more than just *that* a lead came in — they want to know whether it was any good.
 
 | Feature | Free | Professional | Business |
 |---------|:----:|:------------:|:--------:|
 | | | **$39.95/mo** | **$199/mo** |
 | GTM injection | ✅ | ✅ | ✅ |
 | GA4 + Search Console | ✅ | ✅ | ✅ |
+| Native ad pixels (Meta, LinkedIn, TikTok, Bing, Pinterest, Nextdoor) | ✅ | ✅ | ✅ |
 | Header/footer scripts | ✅ | ✅ | ✅ |
 | Call tracking provisioning | ✅ | ✅ | ✅ |
 | Basic call log | ✅ | ✅ | ✅ |
@@ -80,15 +97,15 @@ The free tier stays free forever. Paid tiers add AI intelligence and deeper attr
 | Custom reporting | — | — | ✅ |
 | MCP AI agent access | — | — | ✅ |
 
-**Professional ($39.95/mo)** is built for businesses running paid ads. You get a weekly AI executive summary that tells you what's working, full call transcription and lead scoring, and discounted call tracking rates. At moderate call volume, the lower per-minute rate alone can offset the subscription cost.
+**Professional ($39.95/mo)** is built for businesses running paid ads. You get a weekly AI executive summary that tells you what's working, full call transcription and lead scoring, and lower call tracking rates. For a lot of businesses, the savings on call tracking alone covers the subscription — see the math below.
 
-**Business ($199/mo)** is for high-volume advertisers and agencies. The Ads Advisor watches your ad spend 24/7 — alerting you to budget overruns, underperforming campaigns, and Performance Max anomalies before they cost you. You also get the lowest call tracking rates, custom reporting, and MCP AI agent access to query your marketing data programmatically.
+**Business ($199/mo)** is for high-volume advertisers and agencies. The Ads Advisor watches your Google Ads spend around the clock — alerting you to budget overruns, underperforming campaigns, and automated bidding changes that are quietly costing you money. You also get the lowest call tracking rates, custom reporting, and MCP AI agent access to query your marketing data programmatically.
 
 **Founder's Club ($4,495 one-time)** — Lifetime access to Business tier features, available as a limited-time offer for early adopters. See [ROI Insights](https://roiknowledge.com/?utm_source=github&utm_medium=referral&utm_campaign=emdash-analytics) for availability.
 
-### Does Upgrading Actually Save Money?
+### Does upgrading actually save money?
 
-Because call tracking rates drop significantly with higher tiers, upgrading often costs less overall than staying on the free tier.
+It can — and often does. Because call tracking rates drop with higher tiers, the subscription frequently pays for itself in reduced telecom costs alone.
 
 **Small business running 120 calls/month (avg. 3 min each, 1 tracking number):**
 
@@ -114,22 +131,20 @@ The jump from Professional to Business saves $35/month in telecom costs alone, p
 
 ## Quick Start
 
-### Install via EmDash Marketplace
+### Step 1 — Install the Plugin
 
-```bash
-# From your EmDash project directory
-npx emdash add @mosierdata/emdash-plugin-analytics
-```
-
-### Manual Installation
+From your EmDash project directory, install the package:
 
 ```bash
 npm install @mosierdata/emdash-plugin-analytics
 ```
 
-Add to your `astro.config.mjs`:
+### Step 2 — Register the Plugin
+
+Add the plugin to your `astro.config.mjs`:
 
 ```js
+import { defineConfig } from "astro/config";
 import emdash from "emdash/astro";
 import roiInsights from "@mosierdata/emdash-plugin-analytics/descriptor";
 
@@ -142,15 +157,24 @@ export default defineConfig({
 });
 ```
 
-### Configuration
+### Step 3 — Deploy and Configure
 
-1. Open your EmDash admin panel
-2. Go to **Settings → ROI Insights**
-3. Enter your GTM container ID (e.g., `GTM-XXXXXXX`)
-4. Click **Connect Google Services** to link GA4 and Search Console
-5. (Optional) Enter a license key to unlock Professional or Business features
+Build and deploy your site, then open the EmDash admin panel. The plugin adds three tabs:
 
-That's it. Your tracking is live.
+| Tab | What You'll Do There |
+|-----|---------------------|
+| **License & Google** | Enter your license key (required — free keys are available), connect Google Analytics and Search Console via OAuth |
+| **Tracking Pixels** | Enable/disable GTM, GA4, Meta Pixel, LinkedIn, TikTok, Microsoft UET, Pinterest, and Nextdoor — each with a simple toggle and ID field |
+| **Marketing ROI** | View your embedded analytics dashboard (GA4 traffic, Search Console data, call tracking) |
+
+**Minimum setup (under 60 seconds):**
+
+1. Go to **License & Google** — enter your license key and click **Activate**. Every account needs a key, including the free tier — [get one here](https://roiknowledge.com/?utm_source=github&utm_medium=referral&utm_campaign=emdash-analytics) if you don't have one yet
+2. Still on **License & Google** — click **Connect Google Services** to link GA4 and Search Console via OAuth
+3. Go to **Tracking Pixels** — toggle on Google Tag Manager, paste your GTM container ID (e.g., `GTM-XXXXXXX`), and hit **Save**
+4. (Optional) Enable any additional ad platform pixels you're running — Meta, LinkedIn, TikTok, etc.
+
+That's it. Your tracking is live on every page.
 
 ---
 
@@ -158,19 +182,19 @@ That's it. Your tracking is live.
 
 ## How It Works
 
-The plugin is a lightweight TypeScript package that runs inside EmDash's sandboxed plugin environment on Cloudflare Workers. All the heavy lifting — Google OAuth, call tracking provisioning, AI analysis, billing — happens on a secure backend (`dashboard.mosierdata.com`). The plugin itself stores no secrets and makes no direct third-party API calls.
+The plugin is a lightweight TypeScript package that runs inside EmDash's sandboxed plugin environment on Cloudflare Workers. All the heavy lifting — Google OAuth, call tracking provisioning, AI analysis, billing — happens on a secure backend. The only sensitive value stored locally is your license key (in EmDash's KV store, marked as a `secret` field). Google OAuth tokens are held server-side — they never touch your site's storage.
 
-**Your tracking never breaks.** If our backend is temporarily unreachable, cached tracking scripts keep running. Your analytics data is never lost. We built it this way because we know what it costs when tracking goes dark — even for a day.
+**Your tracking never breaks.** If our backend is temporarily unreachable, your tracking scripts keep running from cache. No analytics data is lost. We built it this way because a single day of broken tracking can mean missed leads and wasted ad spend you'll never recover.
 
-**Your data stays yours.** Google connections are made through your own Google account. If you ever uninstall, your Google Analytics and Search Console data remain completely untouched in your own accounts. We don't hold anything hostage.
+**Your data stays yours.** Google connections are made through your own Google account. If you ever uninstall, your Analytics and Search Console data stay exactly where they are — in your accounts, untouched. We don't hold anything hostage.
 
-**Sandboxed and auditable.** Fully compatible with EmDash's V8 sandboxed plugin isolates on Cloudflare Workers. No filesystem access, no arbitrary network calls. You can inspect every line of code.
+**Sandboxed and auditable.** The plugin is fully compatible with EmDash's V8 sandboxed plugin isolates. No filesystem access, no arbitrary network calls. Every line of code is open source and inspectable.
 
-### How Call Tracking Credits Work
+### How call tracking credits work
 
 Call tracking runs on a prepaid credit system, billed separately from the platform subscription. You purchase credit packages ($10–$250), and credits are deducted based on your active tracking numbers and inbound call minutes. Credits never expire while your account is active.
 
-If your balance runs low, auto-recharge kicks in automatically using your saved payment method — so a call is never dropped because of a low balance, and no lead is lost to a disconnected number.
+You can enable auto-recharge so your balance stays topped up automatically — no lead is ever lost to a disconnected number because you forgot to buy credits.
 
 ---
 
@@ -188,7 +212,9 @@ It launched in April 2026 — which means the ecosystem is young and growing fas
 
 ### Is this really free?
 
-Yes — genuinely free, not "free for 14 days." The free tier gives you GTM injection, GA4 and Search Console connections, header/footer script injection, call tracking provisioning, and a basic call log. No credit card required. Paid tiers add AI transcription, lead scoring, call recording, advanced UTM attribution, and the Ads Advisor — but the core tracking infrastructure works perfectly without them.
+Yes — genuinely free, not "free for 14 days." You do need a license key (even for the free tier), but getting one takes about 30 seconds and doesn't require a credit card. The free tier gives you GTM injection, GA4 and Search Console connections, native toggles for six ad platforms, header/footer script injection, call tracking provisioning, and a basic call log.
+
+Paid tiers add AI transcription, lead scoring, call recording, advanced attribution, and the Ads Advisor — but the core tracking infrastructure works perfectly without them.
 
 ### Do I need a Google Tag Manager account?
 
@@ -196,11 +222,11 @@ Nope. GTM injection is just one of the things this plugin does. You can use it p
 
 ### How does call tracking billing work?
 
-Call tracking runs on a prepaid credit system separate from your platform subscription. You purchase credit packages ($10–$250), and credits are deducted based on your active tracking numbers and inbound call minutes. Credits never expire while your account is active. Auto-recharge keeps your balance topped up automatically so you never lose a call to a low balance.
+Call tracking runs on a prepaid credit system, separate from your platform subscription. You buy credit packages ($10–$250), credits are deducted based on active numbers and call minutes, and they never expire while your account is active. Enable auto-recharge and you'll never have to think about it.
 
 ### Can I use this alongside other EmDash plugins?
 
-Absolutely. The plugin uses EmDash's standard `frontend:inject-head` and `frontend:inject-body` capabilities. It plays nicely with anything else you've installed.
+Absolutely. The plugin uses EmDash's standard `page:fragments` hook to inject tracking scripts. It plays nicely with anything else you've installed.
 
 ### What happens if I cancel a paid subscription?
 
@@ -216,25 +242,19 @@ Yes. If you can paste a GTM container ID and click a "Connect" button, you can s
 
 ### Tech Stack
 - **Plugin:** TypeScript, EmDash Plugin SDK
-- **Tracking engine:** TypeScript, compiled to vanilla JS for CDN delivery
-- **Dashboard:** Embedded directly in your EmDash admin panel
-- **Capabilities used:** `admin:ui`, `frontend:inject-head`, `frontend:inject-body`, `storage:kv`
+- **Admin UI:** React 18 — tracking settings, license/OAuth, and an embedded analytics dashboard
+- **Tracking injection:** `page:fragments` hook — typed `PageFragmentContribution` objects for `head`, `body:start`, and `body:end` zones
+- **Settings storage:** EmDash KV with compare-and-swap (CAS) for atomic saves
+- **Dashboard:** Embedded iframe from the ROI Insights platform
 
-### Plugin Manifest Capabilities
+### Plugin Capabilities
 
-The plugin declares only the permissions it needs. It communicates with a single external host and never makes direct calls to Google, analytics providers, or payment processors.
+The plugin declares only the permissions it needs. It communicates with a single external host (`api.roiknowledge.com`) for license validation and Google OAuth, and never makes direct calls to analytics providers or payment processors. All tracking pixels are injected client-side via page fragments.
 
-```json
+```js
 {
-  "emdash": {
-    "type": "plugin",
-    "capabilities": [
-      "admin:ui",
-      "frontend:inject-head",
-      "frontend:inject-body",
-      "storage:kv"
-    ]
-  }
+  capabilities: ['network:fetch'],
+  allowedHosts: ['api.roiknowledge.com'],
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export function createPlugin() {
     id: 'roi-insights',
     version: '1.0.0',
     capabilities: ['network:fetch'],
-    allowedHosts: ['dashboard.mosierdata.com'],
+    allowedHosts: ['api.roiknowledge.com'],
 
     // Simple user-configurable settings — auto-generates a settings form.
     // Values are stored by EmDash at individual settings:<field> KV keys.
@@ -247,7 +247,7 @@ export function createPlugin() {
           const domain = new URL(ctx.request.url).origin;
           const httpFetch = ctx.http ? ctx.http.fetch.bind(ctx.http) : fetch;
           const response = await httpFetch(
-            'https://dashboard.mosierdata.com/api/roi/plugin/oauth/google/initiate',
+            'https://api.roiknowledge.com/api/roi/plugin/oauth/google/initiate',
             {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },

--- a/src/lib/licensing.ts
+++ b/src/lib/licensing.ts
@@ -4,7 +4,7 @@ import { verifyEd25519Signature } from './crypto';
 
 export const CACHE_KEY = 'state:licenseCache';
 
-const VALIDATE_URL = 'https://dashboard.mosierdata.com/api/roi/plugin/validate';
+const VALIDATE_URL = 'https://api.roiknowledge.com/api/roi/plugin/validate';
 
 // Ed25519 public key from the MosierData signing keypair.
 const PUBLIC_KEY = 'COwQzXhDeQC9uxAdyNFdbFbIrwLAGgtRZlhfAxbR0Dk=';


### PR DESCRIPTION
## Summary
- Document all 6 native ad platform tracking pixels (Meta, LinkedIn, TikTok, Microsoft UET, Pinterest, Nextdoor) with platform descriptions and setup guidance
- Fix quick-start flow: license key is required even on the free tier — old instructions said it was optional, which would leave users with no tracking injection
- Add missing `defineConfig` import so the astro.config.mjs snippet is copy-paste complete
- Fix "eight" vs "six" platform count contradiction
- Correct plugin capabilities from stale `inject-head`/`inject-body` to actual `network:fetch` + `page:fragments`
- Fix false "stores no secrets" claim — license key is stored in KV as a secret field
- Fix CHANGELOG "24-hour KV cache" — expiry is driven by the signed token, not a fixed TTL
- Migrate API hostname from `dashboard.mosierdata.com` to `api.roiknowledge.com`
- Rewrite installation section (remove marketplace path, lead with `npm install`)
- Add 3-tab admin UI documentation (License & Google, Tracking Pixels, Marketing ROI)

## Test plan
- [x] Verify README renders correctly on GitHub (tables, code blocks, images, UTM links)
- [x] Confirm `api.roiknowledge.com` DNS is set up before merging
- [x] Run `npm test` to verify no code regressions from hostname change
- [x] Spot-check that all section header images still display