### PR TITLE
docs: improve CONTRIBUTING.md and add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug Report
+about: Report a problem with tracking, pixel injection, GTM, call tracking, or any other plugin feature
+title: "[Bug] "
+labels: bug
+---
+
+## What happened?
+
+A clear description of what went wrong.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- **EmDash version:**
+- **Plugin version:**
+- **Browser (if relevant):**
+- **Any active plugins or conflicts:**
+
+## Which feature is affected?
+
+<!-- Check all that apply -->
+
+- [ ] GTM injection
+- [ ] GA4
+- [ ] Meta Pixel
+- [ ] LinkedIn
+- [ ] TikTok
+- [ ] Microsoft/Bing Ads
+- [ ] Pinterest
+- [ ] Nextdoor
+- [ ] Call tracking / DNI
+- [ ] Attribution tracking
+- [ ] Event adapters
+- [ ] Header/footer scripts
+- [ ] License activation
+- [ ] Analytics dashboard
+- [ ] Other
+
+## Additional context
+
+Any other details, screenshots, or console errors that might help.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,36 @@
+---
+name: Feature Request
+about: Suggest a new tracking integration, platform pixel, attribution feature, or other improvement
+title: "[Feature] "
+labels: enhancement
+---
+
+## What would you like added or changed?
+
+A clear description of the feature or change you're proposing.
+
+## What problem does this solve?
+
+Explain the underlying need — what are you trying to accomplish that isn't currently possible or easy?
+
+## How are you working around it today?
+
+Describe any current workaround, even if it's manual or incomplete.
+
+## Which area does this relate to?
+
+<!-- Check all that apply -->
+
+- [ ] New platform pixel / tag
+- [ ] Attribution tracking
+- [ ] Event tracking
+- [ ] Call tracking / DNI
+- [ ] GTM integration
+- [ ] Analytics dashboard
+- [ ] EmDash compatibility
+- [ ] Developer API / hooks
+- [ ] Other
+
+## Additional context
+
+Any references, examples from other tools, or mockups that help illustrate the request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,27 @@
 # Contributing to the EmDash Analytics Plugin
 
-Thanks for your interest in contributing to the EmDash Analytics Plugin — the open-source Google Tag Manager, analytics, and call tracking plugin for EmDash CMS provided by [ROI Insights](https://roiknowledge.com) from [MosierData](https://mosierdata.com).
+Thanks for your interest in contributing to the open-source Google Tag Manager, analytics, and call tracking plugin for EmDash CMS by [ROI Insights](https://roiknowledge.com) from [MosierData](https://mosierdata.com). This plugin handles GTM injection, GA4, Meta Pixel, LinkedIn, TikTok, Microsoft Ads, Pinterest, Nextdoor, call tracking with DNI, and attribution tracking — contributions that improve any of these areas are welcome.
 
-## Getting Started
+## Reporting Bugs
+
+Use the [Bug Report template](https://github.com/MosierData/emdash-plugin-analytics/issues/new?template=bug_report.md) when opening an issue. Include your EmDash version, plugin version, browser, and clear steps to reproduce. The more specific you are about which feature is affected (GTM injection, a specific pixel, call tracking, etc.), the faster it gets resolved.
+
+## Requesting Features
+
+Use the [Feature Request template](https://github.com/MosierData/emdash-plugin-analytics/issues/new?template=feature_request.md) for new platform integrations, attribution improvements, or other enhancements. Describe the problem you're solving and how you're currently working around it.
+
+## Pull Requests
+
+1. Fork the repository and create a branch from `main`
+2. Keep PRs focused — one feature or fix per PR
+3. `npm run typecheck` and `npm run test` must pass before opening a PR
+4. Write a clear description of what changed and why
+
+Broad refactors or changes that touch many unrelated areas are harder to review and more likely to be declined. When in doubt, open an issue first.
+
+## Development Setup
+
+See the [For Developers](README.md#for-developers) section of the README for full setup instructions.
 
 ```bash
 git clone https://github.com/MosierData/emdash-plugin-analytics.git
@@ -10,25 +29,12 @@ cd emdash-plugin-analytics
 npm install
 ```
 
-## Development
-
 ```bash
 npm run dev        # build in watch mode
 npm run typecheck  # run TypeScript type checking
 npm run test       # run tests
 ```
 
-## Submitting Changes
-
-1. Fork the repository and create a branch from `main`
-2. Make your changes with clear, focused commits
-3. Ensure `npm run typecheck` and `npm run test` pass
-4. Open a pull request with a description of what changed and why
-
-## Reporting Issues
-
-Please use [GitHub Issues](https://github.com/MosierData/emdash-plugin-analytics/issues) to report bugs or request features. Include your EmDash version, plugin version, and steps to reproduce.
-
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

- Rewrites `CONTRIBUTING.md` to be more specific about the plugin's scope, bug reporting, feature requests, and PR expectations
- Adds `.github/ISSUE_TEMPLATE/bug_report.md` with a feature-area checklist to help triage issues
- Adds `.github/ISSUE_TEMPLATE/feature_request.md` with area checkboxes and a workaround field

## Test plan

- [ ] Verify issue templates appear when opening a new GitHub issue
- [ ] Review `CONTRIBUTING.md` for accuracy against current repo structure